### PR TITLE
Adding support for test categories 

### DIFF
--- a/cucumber-mongodb-rest/src/main/java/at/porscheinformatik/cucumber/mongodb/rest/controller/CollectionController.java
+++ b/cucumber-mongodb-rest/src/main/java/at/porscheinformatik/cucumber/mongodb/rest/controller/CollectionController.java
@@ -80,4 +80,21 @@ public class CollectionController
             }
         }));
     }
+
+    @RequestMapping(value = "/categories", method = RequestMethod.GET)
+    @ResponseBody
+    public Set<String> getCategories() throws IOException
+    {
+        Set<String> collections = getCollections();
+        return ImmutableSet.copyOf(Collections2.transform(collections, new Function<String, String>()
+        {
+            @Override
+            public String apply(final String s)
+            {
+                // e.g. "APPNAME_3.x-SNAPSHOT (Integration)" for integration tests
+                String[] split = s.split(" ");
+                return split.length == 1 ? "" : split[1].replace(")", "");
+            }
+        }));
+    }
 }

--- a/cucumber-mongodb-rest/src/main/java/at/porscheinformatik/cucumber/mongodb/rest/controller/CollectionController.java
+++ b/cucumber-mongodb-rest/src/main/java/at/porscheinformatik/cucumber/mongodb/rest/controller/CollectionController.java
@@ -91,9 +91,9 @@ public class CollectionController
             @Override
             public String apply(final String s)
             {
-                // e.g. "APPNAME_3.x-SNAPSHOT (Integration)" for integration tests
+                // e.g. "APPNAME_3.x-SNAPSHOT Integration" for an  Integration test category
                 String[] split = s.split(" ");
-                return split.length == 1 ? "" : split[1].replace(")", "");
+                return split.length == 1 ? "" : split[1];
             }
         }));
     }

--- a/cucumber-report-web/src/main/resources/static/js/app.js
+++ b/cucumber-report-web/src/main/resources/static/js/app.js
@@ -352,6 +352,10 @@
 				$location.path('/reports/' + product);
 			};
 
+			restApiQueryRequest(categoriesUrl).success(function (res) {
+				$scope.categories = res;
+			});
+
 			restApiQueryRequest(collectionBaseUrl).success(function (data) {
 				$rootScope.showDBError = false;
 				$rootScope.showJSONFileError = false;

--- a/cucumber-report-web/src/main/resources/static/js/config.js
+++ b/cucumber-report-web/src/main/resources/static/js/config.js
@@ -2,6 +2,7 @@ var serverUrl = 'rest/';
 var queryBaseUrl = serverUrl + 'query/';
 var rolesBaseUrl = serverUrl + 'roles/';
 var collectionBaseUrl = serverUrl + 'collection/';
+var categoriesUrl = serverUrl + 'collection/categories';
 var productsUrl = serverUrl + 'collection/products';
 var fileBaseUrl = serverUrl + 'file/';
 var reportFileName = 'report.json';

--- a/cucumber-report-web/src/main/resources/static/pages/products.html
+++ b/cucumber-report-web/src/main/resources/static/pages/products.html
@@ -3,16 +3,16 @@
   <li class="active">Products</li>
 </ol>
 
-<table class="table table-striped table-hover table-bordered">
+<table ng-repeat="category in categories" class="table table-striped table-hover table-bordered">
 	<thead> 
 		<tr>
-			<th class="firstTD">Product / Version</th>
+			<th width="60%" class="firstTD">{{category.length == 0 ? 'Product / Version' : category+' Tests'}}</th>
 			<th>Statistics</th>
 		</tr>
 	</thead>
 	<tbody>
-		<tr ng-repeat="product in filteredProducts | filter:productCondition | filter:searchText | orderBy:'':true">
-			<td class="firstTD"><button ng-click="reportsOverview(product)" class="btn btn-primary btn-sm">{{product}}</button></td>
+		<tr ng-repeat="product in filteredProducts | filter:productCondition | filter:searchText | filter:category | orderBy:'':true">
+			<td class="firstTD"><button ng-click="reportsOverview(product)" class="btn btn-primary btn-sm">{{product.replace(category, '')}}</button></td>
 			<td>
 				<button ng-click="openChart(product)" class="btn btn-primary btn-sm">Charts</button>
 				<button ng-click="openRanking(product)" class="btn btn-primary btn-sm">Rankings</button>		


### PR DESCRIPTION
I added support for different test categories (eg. Acceptance, Integration, Load, Performance, Webservice, ...)
The Category is part of the "Product"-String, defined after the PRODUCT_VERSION with a space as seperator, followed by the category (PRODUCT_VERSION[space]Category)

Examples:
"DUMMY_4.3.1-SNAPSHOT Acceptance"
"DUMMY_4.3.1-SNAPSHOT Webservice"
"DUMMY_4.3.1-SNAPSHOT Load"
"DUMMY_4.3.1-SNAPSHOT Performance"

The feature is backward-compatible, so categories are totally optional. If no categories are used, there is no difference in the application.

There might be much better ways to implement this feature, but I didn't want to change the data model or the whole application hierarchy by myself.

Example Screenshot:
![image](https://cloud.githubusercontent.com/assets/3459599/6683715/f696c476-cc89-11e4-8b5c-160e2ce39d8c.png)